### PR TITLE
Get the project's name from emacs function `project-name` instead of directly using the root dir name

### DIFF
--- a/otpp.el
+++ b/otpp.el
@@ -5,8 +5,8 @@
 ;; Author: Abdelhak Bougouffa (rot13 "nobhtbhssn@srqbencebwrpg.bet")
 ;; URL: https://github.com/abougouffa/one-tab-per-project
 ;; Created: July 07, 2024
-;; Modified: June 15, 2025
-;; Version: 3.4.1
+;; Modified: February 15, 2026
+;; Version: 3.4.2
 ;; Package-Requires: ((emacs "28.1") (compat "29.1"))
 ;; Keywords: convenience
 ;; SPDX-License-Identifier: GPL-3.0
@@ -507,7 +507,8 @@ Then, this function checks in this order:
 1. If the local variable `otpp-project-name' is set locally in the
 `dir-locals-file', use it as project name.
 2. Same with the local variable `project-vc-name'.
-3. Return the directory name of the project's root.
+3. Call and return the value of function `project-name',
+which defaults to the directory name of the project's root.
 
 When DIR isn't part of any project, returns nil."
   (when-let* ((dir (expand-file-name dir))
@@ -529,7 +530,7 @@ When DIR isn't part of any project, returns nil."
                       (or (alist-get var dir-local-variables-alist)
                           (alist-get var file-local-variables-alist)))
                     '(otpp-project-name project-vc-name)))
-          (file-name-nondirectory (directory-file-name root))))))
+          (project-name proj)))))
 
 (defun otpp-find-tabs-by-root-dir (dir)
   "Return a list of tabs that have DIR as `otpp-root-dir' attribute."

--- a/otpp.el
+++ b/otpp.el
@@ -673,7 +673,7 @@ Calls ORIG-FN based on ARGS."
 
 (defun otpp--bury-on-kill-buffer-in-multiple-tabs-a (fn &optional buffer)
   "Advise `kill-buffer' FN to burry BUFFER when it is visible in other tabs."
-  (if-let* ((tabs (and (not (called-interactively-p)) ; when explicitly killing the current buffer, just obey
+  (if-let* ((tabs (and (not (called-interactively-p fn)) ; when explicitly killing the current buffer, just obey
                        otpp-bury-on-kill-buffer-when-multiple-tabs
                        (tab-bar-get-buffer-tab buffer t t t))))
       (progn


### PR DESCRIPTION
- `project-name` defaults to the same project root directory name, but calling the function lets a user customize the project name however they wish (via overrides, advice, etc.) [this is my need]
- bug fix when calling `called-interactively-p`
