### PR TITLE
Only bury instead of killing when buffer current buffer

### DIFF
--- a/otpp.el
+++ b/otpp.el
@@ -674,6 +674,7 @@ Calls ORIG-FN based on ARGS."
 (defun otpp--bury-on-kill-buffer-in-multiple-tabs-a (fn &optional buffer)
   "Advise `kill-buffer' FN to burry BUFFER when it is visible in other tabs."
   (if-let* ((tabs (and (not (called-interactively-p)) ; when explicitly killing the current buffer, just obey
+                       (or (null buffer) (eq (get-buffer buffer) (current-buffer)))
                        otpp-bury-on-kill-buffer-when-multiple-tabs
                        (tab-bar-get-buffer-tab buffer t t t))))
       (progn


### PR DESCRIPTION
Docs for `otpp-bury-on-kill-buffer-when-multiple-tabs` say:

> This only affects the current buffer, when we explicitly select another buffer to kill, `otpp' assumes that we have a good reason to kill it.

However, `otpp--bury-on-kill-buffer-in-multiple-tabs-a` does not respect that limitation.